### PR TITLE
Update go.mod to have correct module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module merlin
+module github.com/gtank/merlin
 
 go 1.12
 


### PR DESCRIPTION
Currently go mod errors:

```
go: github.com/gtank/merlin@v0.1.0: parsing go.mod: unexpected module path "merlin"
go: error loading module requirements

```